### PR TITLE
emit screenshot-on-failure in v8

### DIFF
--- a/packages/wdio-browserstack-service/src/cli/frameworks/wdioMochaTestFramework.ts
+++ b/packages/wdio-browserstack-service/src/cli/frameworks/wdioMochaTestFramework.ts
@@ -199,12 +199,14 @@ export default class WdioMochaTestFramework extends TestFramework {
      */
     loadLogEntries(instance: TestFrameworkInstance, testFrameworkState: State, hookState: State, logEntry: Record<string, unknown>) {
         const logRecord: Record<string, unknown> = {}
-        const { level, message, timestamp } = logEntry
+        const { level, message, timestamp, kind } = logEntry
 
         if (CLIUtils.matchHookRegex(instance.getCurrentTestState().toString())) {
             logRecord[TestFrameworkConstants.KEY_HOOK_ID] = TestFramework.getState(instance, TestFrameworkConstants.KEY_HOOK_ID)
         }
-        logRecord.kind = TestFrameworkConstants.KIND_LOG
+        // SDK-6277: honor the incoming log kind (e.g. TEST_SCREENSHOT) so screenshots route correctly
+        // on the binary side; default to TEST_LOG for ordinary stdout/console logs.
+        logRecord.kind = (kind as string) ?? TestFrameworkConstants.KIND_LOG
         logRecord.message = Buffer.from(message as string)
         logRecord.level = level
         logRecord.timestamp = timestamp

--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -584,6 +584,7 @@ class _InsightsHandler {
                     logEntry: {
                         kind: 'TEST_SCREENSHOT',
                         message: result.value,
+                        level: 'INFO',
                         timestamp: new Date().toISOString()
                     }
                 })

--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -573,12 +573,34 @@ class _InsightsHandler {
         const body = 'body' in args ? args.body : undefined
         const result = 'result' in args ? args.result : undefined
         if (Boolean(process.env[TESTOPS_SCREENSHOT_ENV]) && isScreenshotCommand(args) && result?.value) {
-            await this.listener.onScreenshot([{
-                test_run_uuid: testMeta.uuid,
-                timestamp: new Date().toISOString(),
-                message: result.value,
-                kind: 'TEST_SCREENSHOT'
-            }])
+            /**
+             * SDK-6277: in the CLI/binary (v8) flow, forward the screenshot to the binary over gRPC
+             * as a TEST_SCREENSHOT log. The binary uploads it via its own authorized testhub session.
+             * The direct-HTTP listener.onScreenshot() path 401s in CLI mode (the worker's binary-issued
+             * JWT is not valid for direct collector POSTs).
+             */
+            await (BrowserstackCLI.getInstance().isRunning()
+                ? BrowserstackCLI.getInstance().getTestFramework()!.trackEvent(TestFrameworkState.LOG, HookState.POST, {
+                    logEntry: {
+                        kind: 'TEST_SCREENSHOT',
+                        message: result.value,
+                        timestamp: new Date().toISOString()
+                    }
+                })
+                : this.listener.onScreenshot([{
+                    test_run_uuid: testMeta.uuid,
+                    timestamp: new Date().toISOString(),
+                    message: result.value,
+                    kind: 'TEST_SCREENSHOT'
+                }]))
+        }
+
+        if (BrowserstackCLI.getInstance().isRunning()) {
+            /**
+             * SDK-6277: in CLI mode the binary captures command/network logs itself; the service only
+             * forwards the screenshot above. The direct-HTTP per-command logCreated() path 401s here.
+             */
+            return
         }
 
         const requestData = this._commands[dataKey]

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -258,7 +258,8 @@ export default class BrowserstackService implements Services.ServiceInstance {
                          * forwarded for screenshot-on-failure. Without this the screenshot is dropped in v8.
                          * (browserCommand routes the screenshot over gRPC in CLI mode — see insights-handler.)
                          */
-                        this._browser.on('command', async (command) => {
+                        // 'client:beforeCommand' only records the command synchronously — no await needed.
+                        this._browser.on('command', (command) => {
                             if (shouldProcessEventForTesthub('')) {
                                 this._insightsHandler?.browserCommand(
                                     'client:beforeCommand',
@@ -269,11 +270,15 @@ export default class BrowserstackService implements Services.ServiceInstance {
                         })
                         this._browser.on('result', (result) => {
                             if (shouldProcessEventForTesthub('')) {
+                                // 'client:afterCommand' is async in CLI mode (forwards the screenshot to the
+                                // binary over gRPC). Handle the returned promise so a failed upload is logged
+                                // rather than dropped. (o11yClassErrorHandler also routes method errors to
+                                // processError; this .catch makes the call-site handling explicit.)
                                 this._insightsHandler?.browserCommand(
                                     'client:afterCommand',
                                     Object.assign(result, { sessionId }),
                                     this._currentTest
-                                )
+                                )?.catch((err: unknown) => BStackLogger.debug(`Error forwarding afterCommand in CLI mode: ${err}`))
                             }
                         })
                         PerformanceTester.end(PERFORMANCE_SDK_EVENTS.DRIVER_EVENT.PRE_INITIALIZE)

--- a/packages/wdio-browserstack-service/src/service.ts
+++ b/packages/wdio-browserstack-service/src/service.ts
@@ -252,6 +252,30 @@ export default class BrowserstackService implements Services.ServiceInstance {
                     if (BrowserstackCLI.getInstance().isRunning()) {
                         await BrowserstackCLI.getInstance().getAutomationFramework()!.trackEvent(AutomationFrameworkState.CREATE, HookState.POST, { browser: this._browser, hubUrl: this._config.hostname })
                         this._insightsHandler.setGitConfigPath()
+                        /**
+                         * SDK-6277: register the command/result listeners in the CLI/binary flow too,
+                         * so the user's saveScreenshot()/takeScreenshot() command result is captured and
+                         * forwarded for screenshot-on-failure. Without this the screenshot is dropped in v8.
+                         * (browserCommand routes the screenshot over gRPC in CLI mode — see insights-handler.)
+                         */
+                        this._browser.on('command', async (command) => {
+                            if (shouldProcessEventForTesthub('')) {
+                                this._insightsHandler?.browserCommand(
+                                    'client:beforeCommand',
+                                    Object.assign(command, { sessionId }),
+                                    this._currentTest
+                                )
+                            }
+                        })
+                        this._browser.on('result', (result) => {
+                            if (shouldProcessEventForTesthub('')) {
+                                this._insightsHandler?.browserCommand(
+                                    'client:afterCommand',
+                                    Object.assign(result, { sessionId }),
+                                    this._currentTest
+                                )
+                            }
+                        })
                         PerformanceTester.end(PERFORMANCE_SDK_EVENTS.DRIVER_EVENT.PRE_INITIALIZE)
                         return
                     }


### PR DESCRIPTION
…binary flow (SDK-6277)

In the v8 CLI/binary flow (BrowserstackCLI.isRunning()===true) the browser command/result listeners that capture a screenshot WebDriver command result were registered only in the !isRunning() branch, so a user's saveScreenshot()/ takeScreenshot() on failure was captured on the device but never forwarded to Test Observability (no TEST_SCREENSHOT event). v7 has no binary, so the listeners register and screenshots upload — hence works v7, broken v8.

Fix:
- service.ts: register the command/result listeners in the CLI branch too.
- insights-handler.ts: in CLI mode forward the screenshot to the binary over gRPC as a TEST_SCREENSHOT log via trackEvent(LOG) (the worker's direct-HTTP upload is not authorized in the v8 central-auth flow); skip the direct per-command HTTP log in CLI mode.
- wdioMochaTestFramework.ts: honor the incoming logEntry.kind (default TEST_LOG) so the screenshot keeps kind TEST_SCREENSHOT.

Verified end-to-end against a v8 repro: cloud accepted the screenshot upload (server={"success":true}).

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
